### PR TITLE
Fix potential shortcut bug

### DIFF
--- a/src/templates.js
+++ b/src/templates.js
@@ -55,7 +55,7 @@ function handleTextArea(textarea) {
 	textarea.addEventListener("input", () => {
 		textarea.value = textarea.value.replace(/\!\!\S*/, (match) => {
 			// now you don't have to clear the composer to use a shortcut
-			return shortcuts[match] || match
+			return shortcuts[match] + " " || match // avoid !!LUA vs !!LUAU confusion
 		})
 	})
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -53,7 +53,7 @@ function handleTextArea(textarea) {
 	if (textarea.classList.contains("-!--templates-added")) return false
 
 	textarea.addEventListener("input", () => {
-		textarea.value = textarea.value.replace(/\!\!\S*/, (match) => {
+		textarea.value = textarea.value.replace(/\!\!\S* /, (match) => {
 			// now you don't have to clear the composer to use a shortcut
 			return shortcuts[match] + " " || match // avoid !!LUA vs !!LUAU confusion
 		})

--- a/src/templates.js
+++ b/src/templates.js
@@ -54,8 +54,7 @@ function handleTextArea(textarea) {
 
 	textarea.addEventListener("input", () => {
 		textarea.value = textarea.value.replace(/\!\!\S* /, (match) => {
-			// now you don't have to clear the composer to use a shortcut
-			return shortcuts[match] + " " || match // avoid !!LUA vs !!LUAU confusion
+			return shortcuts[match] + " " || match
 		})
 	})
 


### PR DESCRIPTION
Fixed potential shortcut bug where shorter shortcuts containing the same characters as others would override them(e.g: !!LUA vs !!LUAU)

User is required to press space after entering the shortcut to replace it with desired text